### PR TITLE
ColorMapEditor : reduce css style scope

### DIFF
--- a/vue-components/src/components/colormapper/NodeList.vue
+++ b/vue-components/src/components/colormapper/NodeList.vue
@@ -349,7 +349,7 @@ export default {
   </v-data-table>
 </template>
 
-<style>
+<style scoped>
 tr.selected {
   background-color: rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
The attribute  `display: none` of `.v-btn` in colormapeditor is leaking affecting other widgets. In my case the scalar range widget which results in its control buttons being invisible.
